### PR TITLE
BREAKING CHANGE: Avoid prefixing parameters with new

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ You can find links to the documentation at https://cloud.ibm.com/docs/security-a
 There are also auto-generated JSDocs available at http://ibm-cloud-security.github.io/security-advisor-findings-sdk-nodejs
 
 ## Questions
-If you are having difficulties using the APIs or have a question about the Watson services, please ask a question at [dW Answers](https://developer.ibm.com/answers/questions/ask) or [Stack Overflow](http://stackoverflow.com/questions/ask).
+If you are having difficulties using the APIs or have a question about the IBM Cloud Security Advisor offering, please ask a question at [dW Answers](https://developer.ibm.com/answers/questions/ask) or [Stack Overflow](http://stackoverflow.com/questions/ask).
 
 ## Debug
 This module uses the [`debug`](https://github.com/visionmedia/debug) package for logging. Specify the desired environment variable to enable logging debug messages.
@@ -253,6 +253,6 @@ We love to highlight cool open-source projects that use this SDK! If you'd like 
 This library is licensed under Apache 2.0. Full license text is available in
 [LICENSE][license].
 
-[ibm-cloud-onboarding]: http://cloud.ibm.com/registration?target=/developer/watson&cm_sp=WatsonPlatform-WatsonServices-_-OnPageNavLink-IBMWatson_SDKs-_-Node
+[ibm-cloud-onboarding]: https://cloud.ibm.com/registration?state=%2Fsecurity-advisor%23%2Fdashboard
 [ibm-open-source]: http://ibm.github.io/
 [license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/examples/findings_api.v1.js
+++ b/examples/findings_api.v1.js
@@ -50,20 +50,25 @@ let createNotes = async () => {
   await Promise.all(
     notes.map(async n => {
       try {
-        console.log('Creating note with id', n.newId);
-        await findingsAPIClient.createNote(Object.assign({ accountId: process.env.account_id }, n));
-        console.log('Created note with id', n.newId);
+        console.log('Creating note with id', n.id);
+        await findingsAPIClient.createNote(
+          Object.assign({ accountId: process.env.account_id, providerId: 'security-advisor' }, n)
+        );
+        console.log('Created note with id', n.id);
       } catch (err) {
-        console.log('Note creation failed for id', n.newId, err.message);
+        console.log('Note creation failed for id', n.id, err.message);
         if (err.status == 409) {
           try {
-            console.log('Trying to update note with id', n.newId);
+            console.log('Trying to update note with id', n.id);
             await findingsAPIClient.updateNote(
-              Object.assign({ accountId: process.env.account_id, noteId: n.newId }, n)
+              Object.assign(
+                { accountId: process.env.account_id, noteId: n.id, providerId: 'security-advisor' },
+                n
+              )
             );
-            console.log('Successfully updated note with id', n.newId);
+            console.log('Successfully updated note with id', n.id);
           } catch (err) {
-            console.log('Note update failed for id', n.newId, err.message);
+            console.log('Note update failed for id', n.id, err.message);
           }
         }
       }
@@ -75,29 +80,29 @@ let createOccurrences = async () => {
   await Promise.all(
     occurrences.map(async o => {
       try {
-        console.log('Creating occurence with id', o.newId);
+        console.log('Creating occurence with id', o.id);
         await findingsAPIClient.createOccurrence(
           Object.assign({ accountId: process.env.account_id, providerId: 'security-advisor' }, o)
         );
-        console.log('Created occurence with id', o.newId);
+        console.log('Created occurence with id', o.id);
       } catch (err) {
-        console.log('Occurence creation failed for id', o.newId, err.message);
+        console.log('Occurence creation failed for id', o.id, err.message);
         if (err.status == 409) {
           try {
-            console.log('Trying to update occurence with id', o.newId);
+            console.log('Trying to update occurence with id', o.id);
             await findingsAPIClient.updateOccurrence(
               Object.assign(
                 {
                   accountId: process.env.account_id,
                   providerId: 'security-advisor',
-                  occurrenceId: o.newId,
+                  occurrenceId: o.id,
                 },
                 o
               )
             );
-            console.log('Successfully updated occurence with id', o.newId);
+            console.log('Successfully updated occurence with id', o.id);
           } catch (err) {
-            console.log('Note update failed for id', o.newId, err.message);
+            console.log('Note update failed for id', o.id, err.message);
           }
         }
       }

--- a/examples/resources/notes.js
+++ b/examples/resources/notes.js
@@ -1,16 +1,15 @@
 module.exports = [
   {
-    newKind: 'CARD',
-    providerId: 'security-advisor',
-    newId: 'mycard',
-    newShortDescription: 'card short description',
-    newLongDescription: 'card long description',
-    newReportedBy: {
+    kind: 'CARD',
+    id: 'mycard',
+    shortDescription: 'card short description',
+    longDescription: 'card long description',
+    reportedBy: {
       id: 'myprovider',
       title: 'My provider',
       url: 'https://example.com',
     },
-    newCard: {
+    card: {
       section: 'Business Partner Tools',
       title: 'SampleCard',
       subtitle: 'Sample Card',
@@ -32,17 +31,16 @@ module.exports = [
   },
 
   {
-    newKind: 'FINDING',
-    providerId: 'security-advisor',
-    newId: 'mynote',
-    newShortDescription: 'Notes short description',
-    newLongDescription: 'Notes long description',
-    newReportedBy: {
+    kind: 'FINDING',
+    id: 'mynote',
+    shortDescription: 'Notes short description',
+    longDescription: 'Notes long description',
+    reportedBy: {
       id: 'My provider',
       title: 'My provider',
       url: 'https://www.example.com',
     },
-    newFinding: {
+    finding: {
       severity: 'HIGH',
       next_steps: [
         {
@@ -55,17 +53,16 @@ module.exports = [
     },
   },
   {
-    newKind: 'KPI',
-    providerId: 'security-advisor',
-    newId: 'sample-kpi',
-    newShortDescription: 'kpi short description',
-    newLongDescription: 'kpi long description',
-    newReportedBy: {
+    kind: 'KPI',
+    id: 'sample-kpi',
+    shortDescription: 'kpi short description',
+    longDescription: 'kpi long description',
+    reportedBy: {
       id: 'My provider',
       title: 'My provider',
       url: 'https://www.example.com',
     },
-    newKpi: {
+    kpi: {
       aggregation_type: 'SUM',
       severity: 'HIGH',
     },

--- a/examples/resources/occurrences.js
+++ b/examples/resources/occurrences.js
@@ -1,15 +1,14 @@
 module.exports = [
   {
-    newName: 'occurence1',
-    newResourceUrl: 'string',
-    newNoteName: `${process.env.account_id}/providers/security-advisor/notes/mynote`,
-    newKind: 'FINDING',
-    newProviderId: 'security-advisor',
-    newId: 'occurence1',
-    newContext: {
+    name: 'occurence1',
+    resourceUrl: 'string',
+    noteName: `${process.env.account_id}/providers/security-advisor/notes/mynote`,
+    kind: 'FINDING',
+    id: 'occurence1',
+    context: {
       resource_name: 'myresource',
     },
-    newFinding: {
+    finding: {
       severity: 'LOW',
       certainty: 'LOW',
       next_steps: [
@@ -21,16 +20,15 @@ module.exports = [
     },
   },
   {
-    newName: 'occurence2',
-    newResourceUrl: 'string',
-    newNoteName: `${process.env.account_id}/providers/security-advisor/notes/sample-kpi`,
-    newKind: 'KPI',
-    newProviderId: 'security-advisor',
-    newId: 'occurence2',
-    newContext: {
+    name: 'occurence2',
+    resourceUrl: 'string',
+    noteName: `${process.env.account_id}/providers/security-advisor/notes/sample-kpi`,
+    kind: 'KPI',
+    id: 'occurence2',
+    context: {
       resource_name: 'myresource2',
     },
-    newKpi: {
+    kpi: {
       value: 10,
       total: 100,
     },

--- a/findings-api/v1.ts
+++ b/findings-api/v1.ts
@@ -16,7 +16,13 @@
 
 import * as extend from 'extend';
 import { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http';
-import { Authenticator, BaseService, getAuthenticatorFromEnvironment, getMissingParams, UserOptions } from 'ibm-cloud-sdk-core';
+import {
+  Authenticator,
+  BaseService,
+  getAuthenticatorFromEnvironment,
+  getMissingParams,
+  UserOptions,
+} from 'ibm-cloud-sdk-core';
 import { getSdkHeaders } from '../lib/common';
 
 /**
@@ -24,7 +30,6 @@ import { getSdkHeaders } from '../lib/common';
  */
 
 class FindingsApiV1 extends BaseService {
-
   static DEFAULT_SERVICE_URL: string = 'https://us-south.secadvisor.cloud.ibm.com/findings';
   static DEFAULT_SERVICE_NAME: string = 'findings-api';
 
@@ -57,12 +62,11 @@ class FindingsApiV1 extends BaseService {
     return service;
   }
 
-
   /**
    * Construct a FindingsApiV1 object.
    *
    * @param {Object} options - Options for the service.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net/findings'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://us-south.secadvisor.cloud.ibm.com/findings'). The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {Authenticator} options.authenticator - The Authenticator object used to authenticate requests to the service
    * @constructor
@@ -93,7 +97,9 @@ class FindingsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.Empty>>}
    */
-  public postGraph(params: FindingsApiV1.PostGraphParams): Promise<FindingsApiV1.Response<FindingsApiV1.Empty>> {
+  public postGraph(
+    params: FindingsApiV1.PostGraphParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.Empty>> {
     const _params = extend({}, params);
     const requiredParams = ['accountId', 'body'];
 
@@ -105,7 +111,7 @@ class FindingsApiV1 extends BaseService {
 
       const body = _params.body;
       const path = {
-        'account_id': _params.accountId
+        account_id: _params.accountId,
       };
 
       const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'postGraph');
@@ -118,16 +124,21 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-            'Content-Type': _params.contentType
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+              'Content-Type': _params.contentType,
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /*************************
    * findingsNotes
@@ -140,31 +151,40 @@ class FindingsApiV1 extends BaseService {
    * @param {string} params.accountId - Account ID.
    * @param {string} params.providerId - Part of `parent`. This field contains the provider_id for example:
    * providers/{provider_id}.
-   * @param {string} params.newShortDescription - A one sentence description of this `Note`.
-   * @param {string} params.newLongDescription - A detailed description of this `Note`.
-   * @param {ApiNoteKind} params.newKind - Output only. This explicitly denotes which kind of note is specified. This
+   * @param {string} params.shortDescription - A one sentence description of this `Note`.
+   * @param {string} params.longDescription - A detailed description of this `Note`.
+   * @param {ApiNoteKind} params.kind - Output only. This explicitly denotes which kind of note is specified. This
    * field can be used as a filter in list requests.
-   * @param {string} params.newId -
-   * @param {Reporter} params.newReportedBy - Details about the reporter of this `Note`.
-   * @param {string} [params.newName] -
-   * @param {ApiNoteRelatedUrl[]} [params.newRelatedUrl] -
-   * @param {string} [params.newExpirationTime] - Time of expiration for this note, null if note does not expire.
-   * @param {string} [params.newCreateTime] - Output only. The time this note was created. This field can be used as a
+   * @param {string} params.id -
+   * @param {Reporter} params.reportedBy - Details about the reporter of this `Note`.
+   * @param {string} [params.name] -
+   * @param {ApiNoteRelatedUrl[]} [params.relatedUrl] -
+   * @param {string} [params.expirationTime] - Time of expiration for this note, null if note does not expire.
+   * @param {string} [params.createTime] - Output only. The time this note was created. This field can be used as a
    * filter in list requests.
-   * @param {string} [params.newUpdateTime] - Output only. The time this note was last updated. This field can be used
-   * as a filter in list requests.
-   * @param {string} [params.newProviderId] -
-   * @param {boolean} [params.newShared] - True if this `Note` can be shared by multiple accounts.
-   * @param {FindingType} [params.newFinding] - The finding details of the note.
-   * @param {KpiType} [params.newKpi] - The KPI details of the note.
-   * @param {Card} [params.newCard] - The card details of the note.
-   * @param {Section} [params.newSection] - The section details of the note.
+   * @param {string} [params.updateTime] - Output only. The time this note was last updated. This field can be used as a
+   * filter in list requests.
+   * @param {boolean} [params.shared] - True if this `Note` can be shared by multiple accounts.
+   * @param {FindingType} [params.finding] - The finding details of the note.
+   * @param {KpiType} [params.kpi] - The KPI details of the note.
+   * @param {Card} [params.card] - The card details of the note.
+   * @param {Section} [params.section] - The section details of the note.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>>}
    */
-  public createNote(params: FindingsApiV1.CreateNoteParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>> {
+  public createNote(
+    params: FindingsApiV1.CreateNoteParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>> {
     const _params = extend({}, params);
-    const requiredParams = ['accountId', 'providerId', 'newShortDescription', 'newLongDescription', 'newKind', 'newId', 'newReportedBy'];
+    const requiredParams = [
+      'accountId',
+      'providerId',
+      'shortDescription',
+      'longDescription',
+      'kind',
+      'id',
+      'reportedBy',
+    ];
 
     return new Promise((resolve, reject) => {
       const missingParams = getMissingParams(_params, requiredParams);
@@ -173,27 +193,26 @@ class FindingsApiV1 extends BaseService {
       }
 
       const body = {
-        'short_description': _params.newShortDescription,
-        'long_description': _params.newLongDescription,
-        'kind': _params.newKind,
-        'id': _params.newId,
-        'reported_by': _params.newReportedBy,
-        'name': _params.newName,
-        'related_url': _params.newRelatedUrl,
-        'expiration_time': _params.newExpirationTime,
-        'create_time': _params.newCreateTime,
-        'update_time': _params.newUpdateTime,
-        'provider_id': _params.newProviderId,
-        'shared': _params.newShared,
-        'finding': _params.newFinding,
-        'kpi': _params.newKpi,
-        'card': _params.newCard,
-        'section': _params.newSection
+        short_description: _params.shortDescription,
+        long_description: _params.longDescription,
+        kind: _params.kind,
+        id: _params.id,
+        reported_by: _params.reportedBy,
+        name: _params.name,
+        related_url: _params.relatedUrl,
+        expiration_time: _params.expirationTime,
+        create_time: _params.createTime,
+        update_time: _params.updateTime,
+        shared: _params.shared,
+        finding: _params.finding,
+        kpi: _params.kpi,
+        card: _params.card,
+        section: _params.section,
       };
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
       };
 
       const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'createNote');
@@ -206,16 +225,21 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /**
    * Lists all `Notes` for a given provider.
@@ -229,7 +253,9 @@ class FindingsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiListNotesResponse>>}
    */
-  public listNotes(params: FindingsApiV1.ListNotesParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiListNotesResponse>> {
+  public listNotes(
+    params: FindingsApiV1.ListNotesParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiListNotesResponse>> {
     const _params = extend({}, params);
     const requiredParams = ['accountId', 'providerId'];
 
@@ -240,13 +266,13 @@ class FindingsApiV1 extends BaseService {
       }
 
       const query = {
-        'page_size': _params.pageSize,
-        'page_token': _params.pageToken
+        page_size: _params.pageSize,
+        page_token: _params.pageToken,
       };
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
       };
 
       const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'listNotes');
@@ -259,15 +285,20 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /**
    * Returns the requested `Note`.
@@ -279,7 +310,9 @@ class FindingsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>>}
    */
-  public getNote(params: FindingsApiV1.GetNoteParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>> {
+  public getNote(
+    params: FindingsApiV1.GetNoteParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>> {
     const _params = extend({}, params);
     const requiredParams = ['accountId', 'providerId', 'noteId'];
 
@@ -290,9 +323,9 @@ class FindingsApiV1 extends BaseService {
       }
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId,
-        'note_id': _params.noteId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
+        note_id: _params.noteId,
       };
 
       const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'getNote');
@@ -304,15 +337,20 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /**
    * Updates an existing `Note`.
@@ -321,31 +359,41 @@ class FindingsApiV1 extends BaseService {
    * @param {string} params.accountId - Account ID.
    * @param {string} params.providerId - First part of note `name`: providers/{provider_id}/notes/{note_id}.
    * @param {string} params.noteId - Second part of note `name`: providers/{provider_id}/notes/{note_id}.
-   * @param {string} params.newShortDescription - A one sentence description of this `Note`.
-   * @param {string} params.newLongDescription - A detailed description of this `Note`.
-   * @param {ApiNoteKind} params.newKind - Output only. This explicitly denotes which kind of note is specified. This
+   * @param {string} params.shortDescription - A one sentence description of this `Note`.
+   * @param {string} params.longDescription - A detailed description of this `Note`.
+   * @param {ApiNoteKind} params.kind - Output only. This explicitly denotes which kind of note is specified. This
    * field can be used as a filter in list requests.
-   * @param {string} params.newId -
-   * @param {Reporter} params.newReportedBy - Details about the reporter of this `Note`.
-   * @param {string} [params.newName] -
-   * @param {ApiNoteRelatedUrl[]} [params.newRelatedUrl] -
-   * @param {string} [params.newExpirationTime] - Time of expiration for this note, null if note does not expire.
-   * @param {string} [params.newCreateTime] - Output only. The time this note was created. This field can be used as a
+   * @param {string} params.id -
+   * @param {Reporter} params.reportedBy - Details about the reporter of this `Note`.
+   * @param {string} [params.name] -
+   * @param {ApiNoteRelatedUrl[]} [params.relatedUrl] -
+   * @param {string} [params.expirationTime] - Time of expiration for this note, null if note does not expire.
+   * @param {string} [params.createTime] - Output only. The time this note was created. This field can be used as a
    * filter in list requests.
-   * @param {string} [params.newUpdateTime] - Output only. The time this note was last updated. This field can be used
-   * as a filter in list requests.
-   * @param {string} [params.newProviderId] -
-   * @param {boolean} [params.newShared] - True if this `Note` can be shared by multiple accounts.
-   * @param {FindingType} [params.newFinding] - The finding details of the note.
-   * @param {KpiType} [params.newKpi] - The KPI details of the note.
-   * @param {Card} [params.newCard] - The card details of the note.
-   * @param {Section} [params.newSection] - The section details of the note.
+   * @param {string} [params.updateTime] - Output only. The time this note was last updated. This field can be used as a
+   * filter in list requests.
+   * @param {boolean} [params.shared] - True if this `Note` can be shared by multiple accounts.
+   * @param {FindingType} [params.finding] - The finding details of the note.
+   * @param {KpiType} [params.kpi] - The KPI details of the note.
+   * @param {Card} [params.card] - The card details of the note.
+   * @param {Section} [params.section] - The section details of the note.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>>}
    */
-  public updateNote(params: FindingsApiV1.UpdateNoteParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>> {
+  public updateNote(
+    params: FindingsApiV1.UpdateNoteParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>> {
     const _params = extend({}, params);
-    const requiredParams = ['accountId', 'providerId', 'noteId', 'newShortDescription', 'newLongDescription', 'newKind', 'newId', 'newReportedBy'];
+    const requiredParams = [
+      'accountId',
+      'providerId',
+      'noteId',
+      'shortDescription',
+      'longDescription',
+      'kind',
+      'id',
+      'reportedBy',
+    ];
 
     return new Promise((resolve, reject) => {
       const missingParams = getMissingParams(_params, requiredParams);
@@ -354,28 +402,27 @@ class FindingsApiV1 extends BaseService {
       }
 
       const body = {
-        'short_description': _params.newShortDescription,
-        'long_description': _params.newLongDescription,
-        'kind': _params.newKind,
-        'id': _params.newId,
-        'reported_by': _params.newReportedBy,
-        'name': _params.newName,
-        'related_url': _params.newRelatedUrl,
-        'expiration_time': _params.newExpirationTime,
-        'create_time': _params.newCreateTime,
-        'update_time': _params.newUpdateTime,
-        'provider_id': _params.newProviderId,
-        'shared': _params.newShared,
-        'finding': _params.newFinding,
-        'kpi': _params.newKpi,
-        'card': _params.newCard,
-        'section': _params.newSection
+        short_description: _params.shortDescription,
+        long_description: _params.longDescription,
+        kind: _params.kind,
+        id: _params.id,
+        reported_by: _params.reportedBy,
+        name: _params.name,
+        related_url: _params.relatedUrl,
+        expiration_time: _params.expirationTime,
+        create_time: _params.createTime,
+        update_time: _params.updateTime,
+        shared: _params.shared,
+        finding: _params.finding,
+        kpi: _params.kpi,
+        card: _params.card,
+        section: _params.section,
       };
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId,
-        'note_id': _params.noteId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
+        note_id: _params.noteId,
       };
 
       const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'updateNote');
@@ -388,16 +435,21 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /**
    * Deletes the given `Note` from the system.
@@ -409,7 +461,9 @@ class FindingsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.Empty>>}
    */
-  public deleteNote(params: FindingsApiV1.DeleteNoteParams): Promise<FindingsApiV1.Response<FindingsApiV1.Empty>> {
+  public deleteNote(
+    params: FindingsApiV1.DeleteNoteParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.Empty>> {
     const _params = extend({}, params);
     const requiredParams = ['accountId', 'providerId', 'noteId'];
 
@@ -420,9 +474,9 @@ class FindingsApiV1 extends BaseService {
       }
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId,
-        'note_id': _params.noteId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
+        note_id: _params.noteId,
       };
 
       const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteNote');
@@ -434,15 +488,20 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /**
    * Gets the `Note` attached to the given `Occurrence`.
@@ -456,7 +515,9 @@ class FindingsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>>}
    */
-  public getOccurrenceNote(params: FindingsApiV1.GetOccurrenceNoteParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>> {
+  public getOccurrenceNote(
+    params: FindingsApiV1.GetOccurrenceNoteParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiNote>> {
     const _params = extend({}, params);
     const requiredParams = ['accountId', 'providerId', 'occurrenceId'];
 
@@ -467,12 +528,16 @@ class FindingsApiV1 extends BaseService {
       }
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId,
-        'occurrence_id': _params.occurrenceId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
+        occurrence_id: _params.occurrenceId,
       };
 
-      const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'getOccurrenceNote');
+      const sdkHeaders = getSdkHeaders(
+        FindingsApiV1.DEFAULT_SERVICE_NAME,
+        'v1',
+        'getOccurrenceNote'
+      );
 
       const parameters = {
         options: {
@@ -481,15 +546,20 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /*************************
    * findingsOccurrences
@@ -502,31 +572,32 @@ class FindingsApiV1 extends BaseService {
    * @param {string} params.accountId - Account ID.
    * @param {string} params.providerId - Part of `parent`. This contains the provider_id for example:
    * providers/{provider_id}.
-   * @param {string} params.newNoteName - An analysis note associated with this image, in the form
-   * "providers/{provider_id}/notes/{note_id}" This field can be used as a filter in list requests.
-   * @param {ApiNoteKind} params.newKind - Output only. This explicitly denotes which of the `Occurrence` details are
+   * @param {string} params.noteName - An analysis note associated with this image, in the form
+   * "{account_id}/providers/{provider_id}/notes/{note_id}" This field can be used as a filter in list requests.
+   * @param {ApiNoteKind} params.kind - Output only. This explicitly denotes which of the `Occurrence` details are
    * specified.
    * This field can be used as a filter in list requests.
-   * @param {string} params.newId -
-   * @param {string} [params.newName] - Output only. The name of the `Occurrence` in the form
-   * "providers/{provider_id}/occurrences/{occuurence_id}".
-   * @param {string} [params.newResourceUrl] - The unique URL of the resource, image or the container, for which the
+   * @param {string} params.id -
+   * @param {string} [params.name] - Output only. The name of the `Occurrence` in the form
+   * "{account_id}/providers/{provider_id}/occurrences/{occuurence_id}".
+   * @param {string} [params.resourceUrl] - The unique URL of the resource, image or the container, for which the
    * `Occurrence` applies. For example, https://gcr.io/provider/image@sha256:foo. This field can be used as a filter in
    * list requests.
-   * @param {string} [params.newRemediation] -
-   * @param {string} [params.newCreateTime] - Output only. The time this `Occurrence` was created.
-   * @param {string} [params.newUpdateTime] - Output only. The time this `Occurrence` was last updated.
-   * @param {string} [params.newProviderId] -
-   * @param {Context} [params.newContext] - Details about the context of this `Occurrence`.
-   * @param {Finding} [params.newFinding] - Details of the occurrence of a finding.
-   * @param {Kpi} [params.newKpi] - Details of the occurrence of a KPI.
+   * @param {string} [params.remediation] -
+   * @param {string} [params.createTime] - Output only. The time this `Occurrence` was created.
+   * @param {string} [params.updateTime] - Output only. The time this `Occurrence` was last updated.
+   * @param {Context} [params.context] - Details about the context of this `Occurrence`.
+   * @param {Finding} [params.finding] - Details of the occurrence of a finding.
+   * @param {Kpi} [params.kpi] - Details of the occurrence of a KPI.
    * @param {boolean} [params.replaceIfExists] - It allows replacing an existing occurrence when set to true.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiOccurrence>>}
    */
-  public createOccurrence(params: FindingsApiV1.CreateOccurrenceParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiOccurrence>> {
+  public createOccurrence(
+    params: FindingsApiV1.CreateOccurrenceParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiOccurrence>> {
     const _params = extend({}, params);
-    const requiredParams = ['accountId', 'providerId', 'newNoteName', 'newKind', 'newId'];
+    const requiredParams = ['accountId', 'providerId', 'noteName', 'kind', 'id'];
 
     return new Promise((resolve, reject) => {
       const missingParams = getMissingParams(_params, requiredParams);
@@ -535,26 +606,29 @@ class FindingsApiV1 extends BaseService {
       }
 
       const body = {
-        'note_name': _params.newNoteName,
-        'kind': _params.newKind,
-        'id': _params.newId,
-        'name': _params.newName,
-        'resource_url': _params.newResourceUrl,
-        'remediation': _params.newRemediation,
-        'create_time': _params.newCreateTime,
-        'update_time': _params.newUpdateTime,
-        'provider_id': _params.newProviderId,
-        'context': _params.newContext,
-        'finding': _params.newFinding,
-        'kpi': _params.newKpi
+        note_name: _params.noteName,
+        kind: _params.kind,
+        id: _params.id,
+        name: _params.name,
+        resource_url: _params.resourceUrl,
+        remediation: _params.remediation,
+        create_time: _params.createTime,
+        update_time: _params.updateTime,
+        context: _params.context,
+        finding: _params.finding,
+        kpi: _params.kpi,
       };
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
       };
 
-      const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'createOccurrence');
+      const sdkHeaders = getSdkHeaders(
+        FindingsApiV1.DEFAULT_SERVICE_NAME,
+        'v1',
+        'createOccurrence'
+      );
 
       const parameters = {
         options: {
@@ -564,17 +638,22 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-            'Replace-If-Exists': _params.replaceIfExists
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+              'Replace-If-Exists': _params.replaceIfExists,
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /**
    * Lists active `Occurrences` for a given provider matching the filters.
@@ -588,7 +667,9 @@ class FindingsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiListOccurrencesResponse>>}
    */
-  public listOccurrences(params: FindingsApiV1.ListOccurrencesParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiListOccurrencesResponse>> {
+  public listOccurrences(
+    params: FindingsApiV1.ListOccurrencesParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiListOccurrencesResponse>> {
     const _params = extend({}, params);
     const requiredParams = ['accountId', 'providerId'];
 
@@ -599,13 +680,13 @@ class FindingsApiV1 extends BaseService {
       }
 
       const query = {
-        'page_size': _params.pageSize,
-        'page_token': _params.pageToken
+        page_size: _params.pageSize,
+        page_token: _params.pageToken,
       };
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
       };
 
       const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'listOccurrences');
@@ -618,15 +699,20 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /**
    * Lists `Occurrences` referencing the specified `Note`. Use this method to get all occurrences referencing your `Note` across all your customer providers.
@@ -640,7 +726,9 @@ class FindingsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiListNoteOccurrencesResponse>>}
    */
-  public listNoteOccurrences(params: FindingsApiV1.ListNoteOccurrencesParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiListNoteOccurrencesResponse>> {
+  public listNoteOccurrences(
+    params: FindingsApiV1.ListNoteOccurrencesParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiListNoteOccurrencesResponse>> {
     const _params = extend({}, params);
     const requiredParams = ['accountId', 'providerId', 'noteId'];
 
@@ -651,17 +739,21 @@ class FindingsApiV1 extends BaseService {
       }
 
       const query = {
-        'page_size': _params.pageSize,
-        'page_token': _params.pageToken
+        page_size: _params.pageSize,
+        page_token: _params.pageToken,
       };
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId,
-        'note_id': _params.noteId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
+        note_id: _params.noteId,
       };
 
-      const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'listNoteOccurrences');
+      const sdkHeaders = getSdkHeaders(
+        FindingsApiV1.DEFAULT_SERVICE_NAME,
+        'v1',
+        'listNoteOccurrences'
+      );
 
       const parameters = {
         options: {
@@ -671,15 +763,20 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /**
    * Returns the requested `Occurrence`.
@@ -693,7 +790,9 @@ class FindingsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiListOccurrencesResponse>>}
    */
-  public getOccurrence(params: FindingsApiV1.GetOccurrenceParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiListOccurrencesResponse>> {
+  public getOccurrence(
+    params: FindingsApiV1.GetOccurrenceParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiListOccurrencesResponse>> {
     const _params = extend({}, params);
     const requiredParams = ['accountId', 'providerId', 'occurrenceId'];
 
@@ -704,9 +803,9 @@ class FindingsApiV1 extends BaseService {
       }
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId,
-        'occurrence_id': _params.occurrenceId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
+        occurrence_id: _params.occurrenceId,
       };
 
       const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'getOccurrence');
@@ -718,15 +817,20 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /**
    * Updates an existing `Occurrence`.
@@ -737,30 +841,31 @@ class FindingsApiV1 extends BaseService {
    * providers/{provider_id}/occurrences/{occurrence_id}.
    * @param {string} params.occurrenceId - Second part of occurrence `name`:
    * providers/{provider_id}/occurrences/{occurrence_id}.
-   * @param {string} params.newNoteName - An analysis note associated with this image, in the form
-   * "providers/{provider_id}/notes/{note_id}" This field can be used as a filter in list requests.
-   * @param {ApiNoteKind} params.newKind - Output only. This explicitly denotes which of the `Occurrence` details are
+   * @param {string} params.noteName - An analysis note associated with this image, in the form
+   * "{account_id}/providers/{provider_id}/notes/{note_id}" This field can be used as a filter in list requests.
+   * @param {ApiNoteKind} params.kind - Output only. This explicitly denotes which of the `Occurrence` details are
    * specified.
    * This field can be used as a filter in list requests.
-   * @param {string} params.newId -
-   * @param {string} [params.newName] - Output only. The name of the `Occurrence` in the form
-   * "providers/{provider_id}/occurrences/{occuurence_id}".
-   * @param {string} [params.newResourceUrl] - The unique URL of the resource, image or the container, for which the
+   * @param {string} params.id -
+   * @param {string} [params.name] - Output only. The name of the `Occurrence` in the form
+   * "{account_id}/providers/{provider_id}/occurrences/{occuurence_id}".
+   * @param {string} [params.resourceUrl] - The unique URL of the resource, image or the container, for which the
    * `Occurrence` applies. For example, https://gcr.io/provider/image@sha256:foo. This field can be used as a filter in
    * list requests.
-   * @param {string} [params.newRemediation] -
-   * @param {string} [params.newCreateTime] - Output only. The time this `Occurrence` was created.
-   * @param {string} [params.newUpdateTime] - Output only. The time this `Occurrence` was last updated.
-   * @param {string} [params.newProviderId] -
-   * @param {Context} [params.newContext] - Details about the context of this `Occurrence`.
-   * @param {Finding} [params.newFinding] - Details of the occurrence of a finding.
-   * @param {Kpi} [params.newKpi] - Details of the occurrence of a KPI.
+   * @param {string} [params.remediation] -
+   * @param {string} [params.createTime] - Output only. The time this `Occurrence` was created.
+   * @param {string} [params.updateTime] - Output only. The time this `Occurrence` was last updated.
+   * @param {Context} [params.context] - Details about the context of this `Occurrence`.
+   * @param {Finding} [params.finding] - Details of the occurrence of a finding.
+   * @param {Kpi} [params.kpi] - Details of the occurrence of a KPI.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiOccurrence>>}
    */
-  public updateOccurrence(params: FindingsApiV1.UpdateOccurrenceParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiOccurrence>> {
+  public updateOccurrence(
+    params: FindingsApiV1.UpdateOccurrenceParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiOccurrence>> {
     const _params = extend({}, params);
-    const requiredParams = ['accountId', 'providerId', 'occurrenceId', 'newNoteName', 'newKind', 'newId'];
+    const requiredParams = ['accountId', 'providerId', 'occurrenceId', 'noteName', 'kind', 'id'];
 
     return new Promise((resolve, reject) => {
       const missingParams = getMissingParams(_params, requiredParams);
@@ -769,27 +874,30 @@ class FindingsApiV1 extends BaseService {
       }
 
       const body = {
-        'note_name': _params.newNoteName,
-        'kind': _params.newKind,
-        'id': _params.newId,
-        'name': _params.newName,
-        'resource_url': _params.newResourceUrl,
-        'remediation': _params.newRemediation,
-        'create_time': _params.newCreateTime,
-        'update_time': _params.newUpdateTime,
-        'provider_id': _params.newProviderId,
-        'context': _params.newContext,
-        'finding': _params.newFinding,
-        'kpi': _params.newKpi
+        note_name: _params.noteName,
+        kind: _params.kind,
+        id: _params.id,
+        name: _params.name,
+        resource_url: _params.resourceUrl,
+        remediation: _params.remediation,
+        create_time: _params.createTime,
+        update_time: _params.updateTime,
+        context: _params.context,
+        finding: _params.finding,
+        kpi: _params.kpi,
       };
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId,
-        'occurrence_id': _params.occurrenceId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
+        occurrence_id: _params.occurrenceId,
       };
 
-      const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'updateOccurrence');
+      const sdkHeaders = getSdkHeaders(
+        FindingsApiV1.DEFAULT_SERVICE_NAME,
+        'v1',
+        'updateOccurrence'
+      );
 
       const parameters = {
         options: {
@@ -799,16 +907,21 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /**
    * Deletes the given `Occurrence` from the system.
@@ -821,7 +934,9 @@ class FindingsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.Empty>>}
    */
-  public deleteOccurrence(params: FindingsApiV1.DeleteOccurrenceParams): Promise<FindingsApiV1.Response<FindingsApiV1.Empty>> {
+  public deleteOccurrence(
+    params: FindingsApiV1.DeleteOccurrenceParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.Empty>> {
     const _params = extend({}, params);
     const requiredParams = ['accountId', 'providerId', 'occurrenceId'];
 
@@ -832,12 +947,16 @@ class FindingsApiV1 extends BaseService {
       }
 
       const path = {
-        'account_id': _params.accountId,
-        'provider_id': _params.providerId,
-        'occurrence_id': _params.occurrenceId
+        account_id: _params.accountId,
+        provider_id: _params.providerId,
+        occurrence_id: _params.occurrenceId,
       };
 
-      const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteOccurrence');
+      const sdkHeaders = getSdkHeaders(
+        FindingsApiV1.DEFAULT_SERVICE_NAME,
+        'v1',
+        'deleteOccurrence'
+      );
 
       const parameters = {
         options: {
@@ -846,15 +965,20 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
+  }
 
   /*************************
    * findingsProviders
@@ -870,7 +994,9 @@ class FindingsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<FindingsApiV1.Response<FindingsApiV1.ApiListProvidersResponse>>}
    */
-  public listProviders(params: FindingsApiV1.ListProvidersParams): Promise<FindingsApiV1.Response<FindingsApiV1.ApiListProvidersResponse>> {
+  public listProviders(
+    params: FindingsApiV1.ListProvidersParams
+  ): Promise<FindingsApiV1.Response<FindingsApiV1.ApiListProvidersResponse>> {
     const _params = extend({}, params);
     const requiredParams = ['accountId'];
 
@@ -881,12 +1007,12 @@ class FindingsApiV1 extends BaseService {
       }
 
       const query = {
-        'page_size': _params.pageSize,
-        'page_token': _params.pageToken
+        page_size: _params.pageSize,
+        page_token: _params.pageToken,
       };
 
       const path = {
-        'account_id': _params.accountId
+        account_id: _params.accountId,
       };
 
       const sdkHeaders = getSdkHeaders(FindingsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'listProviders');
@@ -899,16 +1025,20 @@ class FindingsApiV1 extends BaseService {
           path,
         },
         defaultOptions: extend(true, {}, this.baseOptions, {
-          headers: extend(true, sdkHeaders, {
-            'Accept': 'application/json',
-          }, _params.headers),
+          headers: extend(
+            true,
+            sdkHeaders,
+            {
+              Accept: 'application/json',
+            },
+            _params.headers
+          ),
         }),
       };
 
       return resolve(this.createRequest(parameters));
     });
-  };
-
+  }
 }
 
 /*************************
@@ -916,9 +1046,8 @@ class FindingsApiV1 extends BaseService {
  ************************/
 
 namespace FindingsApiV1 {
-
   /** An operation response. */
-  export interface Response<T = any>  {
+  export interface Response<T = any> {
     result: T;
     status: number;
     statusText: string;
@@ -929,7 +1058,7 @@ namespace FindingsApiV1 {
   export type Callback<T> = (error: any, response?: Response<T>) => void;
 
   /** The body of a service request that returns no response data. */
-  export interface Empty { }
+  export interface Empty {}
 
   /** A standard JS object, defined to avoid the limitations of `Object` and `object` */
   export interface JsonObject {
@@ -967,35 +1096,34 @@ namespace FindingsApiV1 {
     /** Part of `parent`. This field contains the provider_id for example: providers/{provider_id}. */
     providerId: string;
     /** A one sentence description of this `Note`. */
-    newShortDescription: string;
+    shortDescription: string;
     /** A detailed description of this `Note`. */
-    newLongDescription: string;
+    longDescription: string;
     /** Output only. This explicitly denotes which kind of note is specified. This
      *  field can be used as a filter in list requests.
      */
-    newKind: ApiNoteKind;
-    newId: string;
+    kind: ApiNoteKind;
+    id: string;
     /** Details about the reporter of this `Note`. */
-    newReportedBy: Reporter;
-    newName?: string;
-    newRelatedUrl?: ApiNoteRelatedUrl[];
+    reportedBy: Reporter;
+    name?: string;
+    relatedUrl?: ApiNoteRelatedUrl[];
     /** Time of expiration for this note, null if note does not expire. */
-    newExpirationTime?: string;
+    expirationTime?: string;
     /** Output only. The time this note was created. This field can be used as a filter in list requests. */
-    newCreateTime?: string;
+    createTime?: string;
     /** Output only. The time this note was last updated. This field can be used as a filter in list requests. */
-    newUpdateTime?: string;
-    newProviderId?: string;
+    updateTime?: string;
     /** True if this `Note` can be shared by multiple accounts. */
-    newShared?: boolean;
+    shared?: boolean;
     /** The finding details of the note. */
-    newFinding?: FindingType;
+    finding?: FindingType;
     /** The KPI details of the note. */
-    newKpi?: KpiType;
+    kpi?: KpiType;
     /** The card details of the note. */
-    newCard?: Card;
+    card?: Card;
     /** The section details of the note. */
-    newSection?: Section;
+    section?: Section;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -1032,35 +1160,34 @@ namespace FindingsApiV1 {
     /** Second part of note `name`: providers/{provider_id}/notes/{note_id}. */
     noteId: string;
     /** A one sentence description of this `Note`. */
-    newShortDescription: string;
+    shortDescription: string;
     /** A detailed description of this `Note`. */
-    newLongDescription: string;
+    longDescription: string;
     /** Output only. This explicitly denotes which kind of note is specified. This
      *  field can be used as a filter in list requests.
      */
-    newKind: ApiNoteKind;
-    newId: string;
+    kind: ApiNoteKind;
+    id: string;
     /** Details about the reporter of this `Note`. */
-    newReportedBy: Reporter;
-    newName?: string;
-    newRelatedUrl?: ApiNoteRelatedUrl[];
+    reportedBy: Reporter;
+    name?: string;
+    relatedUrl?: ApiNoteRelatedUrl[];
     /** Time of expiration for this note, null if note does not expire. */
-    newExpirationTime?: string;
+    expirationTime?: string;
     /** Output only. The time this note was created. This field can be used as a filter in list requests. */
-    newCreateTime?: string;
+    createTime?: string;
     /** Output only. The time this note was last updated. This field can be used as a filter in list requests. */
-    newUpdateTime?: string;
-    newProviderId?: string;
+    updateTime?: string;
     /** True if this `Note` can be shared by multiple accounts. */
-    newShared?: boolean;
+    shared?: boolean;
     /** The finding details of the note. */
-    newFinding?: FindingType;
+    finding?: FindingType;
     /** The KPI details of the note. */
-    newKpi?: KpiType;
+    kpi?: KpiType;
     /** The card details of the note. */
-    newCard?: Card;
+    card?: Card;
     /** The section details of the note. */
-    newSection?: Section;
+    section?: Section;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -1092,33 +1219,34 @@ namespace FindingsApiV1 {
     accountId: string;
     /** Part of `parent`. This contains the provider_id for example: providers/{provider_id}. */
     providerId: string;
-    /** An analysis note associated with this image, in the form "providers/{provider_id}/notes/{note_id}" This
-     *  field can be used as a filter in list requests.
+    /** An analysis note associated with this image, in the form
+     *  "{account_id}/providers/{provider_id}/notes/{note_id}" This field can be used as a filter in list requests.
      */
-    newNoteName: string;
+    noteName: string;
     /** Output only. This explicitly denotes which of the `Occurrence` details are specified.
      *  This field can be used as a filter in list requests.
      */
-    newKind: ApiNoteKind;
-    newId: string;
-    /** Output only. The name of the `Occurrence` in the form "providers/{provider_id}/occurrences/{occuurence_id}". */
-    newName?: string;
+    kind: ApiNoteKind;
+    id: string;
+    /** Output only. The name of the `Occurrence` in the form
+     *  "{account_id}/providers/{provider_id}/occurrences/{occuurence_id}".
+     */
+    name?: string;
     /** The unique URL of the resource, image or the container, for which the `Occurrence` applies. For example,
      *  https://gcr.io/provider/image@sha256:foo. This field can be used as a filter in list requests.
      */
-    newResourceUrl?: string;
-    newRemediation?: string;
+    resourceUrl?: string;
+    remediation?: string;
     /** Output only. The time this `Occurrence` was created. */
-    newCreateTime?: string;
+    createTime?: string;
     /** Output only. The time this `Occurrence` was last updated. */
-    newUpdateTime?: string;
-    newProviderId?: string;
+    updateTime?: string;
     /** Details about the context of this `Occurrence`. */
-    newContext?: Context;
+    context?: Context;
     /** Details of the occurrence of a finding. */
-    newFinding?: Finding;
+    finding?: Finding;
     /** Details of the occurrence of a KPI. */
-    newKpi?: Kpi;
+    kpi?: Kpi;
     /** It allows replacing an existing occurrence when set to true. */
     replaceIfExists?: boolean;
     headers?: OutgoingHttpHeaders;
@@ -1171,33 +1299,34 @@ namespace FindingsApiV1 {
     providerId: string;
     /** Second part of occurrence `name`: providers/{provider_id}/occurrences/{occurrence_id}. */
     occurrenceId: string;
-    /** An analysis note associated with this image, in the form "providers/{provider_id}/notes/{note_id}" This
-     *  field can be used as a filter in list requests.
+    /** An analysis note associated with this image, in the form
+     *  "{account_id}/providers/{provider_id}/notes/{note_id}" This field can be used as a filter in list requests.
      */
-    newNoteName: string;
+    noteName: string;
     /** Output only. This explicitly denotes which of the `Occurrence` details are specified.
      *  This field can be used as a filter in list requests.
      */
-    newKind: ApiNoteKind;
-    newId: string;
-    /** Output only. The name of the `Occurrence` in the form "providers/{provider_id}/occurrences/{occuurence_id}". */
-    newName?: string;
+    kind: ApiNoteKind;
+    id: string;
+    /** Output only. The name of the `Occurrence` in the form
+     *  "{account_id}/providers/{provider_id}/occurrences/{occuurence_id}".
+     */
+    name?: string;
     /** The unique URL of the resource, image or the container, for which the `Occurrence` applies. For example,
      *  https://gcr.io/provider/image@sha256:foo. This field can be used as a filter in list requests.
      */
-    newResourceUrl?: string;
-    newRemediation?: string;
+    resourceUrl?: string;
+    remediation?: string;
     /** Output only. The time this `Occurrence` was created. */
-    newCreateTime?: string;
+    createTime?: string;
     /** Output only. The time this `Occurrence` was last updated. */
-    newUpdateTime?: string;
-    newProviderId?: string;
+    updateTime?: string;
     /** Details about the context of this `Occurrence`. */
-    newContext?: Context;
+    context?: Context;
     /** Details of the occurrence of a finding. */
-    newFinding?: Finding;
+    finding?: Finding;
     /** Details of the occurrence of a KPI. */
-    newKpi?: Kpi;
+    kpi?: Kpi;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -1261,8 +1390,7 @@ namespace FindingsApiV1 {
   }
 
   /** Note provider-assigned confidence on the validity of an occurrence - LOW&#58; Low Certainty - MEDIUM&#58; Medium Certainty - HIGH&#58; High Certainty. */
-  export interface Certainty {
-  }
+  export interface Certainty {}
 
   /** Context. */
   export interface Context {
@@ -1378,8 +1506,7 @@ namespace FindingsApiV1 {
   }
 
   /** Note provider-assigned severity/impact ranking - LOW&#58; Low Impact - MEDIUM&#58; Medium Impact - HIGH&#58; High Impact. */
-  export interface Severity {
-  }
+  export interface Severity {}
 
   /** It provides details about a socket address. */
   export interface SocketAddress {
@@ -1450,7 +1577,6 @@ namespace FindingsApiV1 {
     create_time?: string;
     /** Output only. The time this note was last updated. This field can be used as a filter in list requests. */
     update_time?: string;
-    provider_id?: string;
     id: string;
     /** True if this `Note` can be shared by multiple accounts. */
     shared?: boolean;
@@ -1467,8 +1593,7 @@ namespace FindingsApiV1 {
   }
 
   /** This must be 1&#58;1 with members of our oneofs, it can be used for filtering Note and Occurrence on their kind. - FINDING&#58; The note and occurrence represent a finding. - KPI&#58; The note and occurrence represent a KPI value. - CARD&#58; The note represents a card showing findings and related metric values. - CARD_CONFIGURED&#58; The note represents a card configured for a user account. - SECTION&#58; The note represents a section in a dashboard. */
-  export interface ApiNoteKind {
-  }
+  export interface ApiNoteKind {}
 
   /** Metadata for any related URL information. */
   export interface ApiNoteRelatedUrl {
@@ -1478,14 +1603,16 @@ namespace FindingsApiV1 {
 
   /** `Occurrence` includes information about analysis occurrences for an image. */
   export interface ApiOccurrence {
-    /** Output only. The name of the `Occurrence` in the form "providers/{provider_id}/occurrences/{occuurence_id}". */
+    /** Output only. The name of the `Occurrence` in the form
+     *  "{account_id}/providers/{provider_id}/occurrences/{occuurence_id}".
+     */
     name?: string;
     /** The unique URL of the resource, image or the container, for which the `Occurrence` applies. For example,
      *  https://gcr.io/provider/image@sha256:foo. This field can be used as a filter in list requests.
      */
     resource_url?: string;
-    /** An analysis note associated with this image, in the form "providers/{provider_id}/notes/{note_id}" This
-     *  field can be used as a filter in list requests.
+    /** An analysis note associated with this image, in the form
+     *  "{account_id}/providers/{provider_id}/notes/{note_id}" This field can be used as a filter in list requests.
      */
     note_name: string;
     /** Output only. This explicitly denotes which of the `Occurrence` details are specified.
@@ -1497,7 +1624,6 @@ namespace FindingsApiV1 {
     create_time?: string;
     /** Output only. The time this `Occurrence` was last updated. */
     update_time?: string;
-    provider_id?: string;
     id: string;
     /** Details about the context of this `Occurrence`. */
     context?: Context;
@@ -1517,8 +1643,6 @@ namespace FindingsApiV1 {
   export interface BreakdownCardElement extends CardElement {
     /** The text of this card element. */
     text: string;
-    /** The direction of this breakdown card element. */
-    direction?: string;
     /** the value types associated to this card element. */
     value_types: ValueType[];
   }
@@ -1551,7 +1675,6 @@ namespace FindingsApiV1 {
     /** the value types associated to this card element. */
     value_types: ValueType[];
   }
-
 }
 
 export = FindingsApiV1;

--- a/scripts/jsdoc/template/tmpl/layout.tmpl
+++ b/scripts/jsdoc/template/tmpl/layout.tmpl
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title><?js= title ?> | Watson Developer Cloud Node.js SDK Documentation</title>
+    <title><?js= title ?> | IBM Cloud Security Advisor Node.js SDK Documentation</title>
 
     <script src="scripts/prettify/prettify.js"> </script>
     <script src="scripts/prettify/lang-css.js"> </script>
@@ -34,13 +34,6 @@
 
 <script> prettyPrint(); </script>
 <script src="scripts/linenumber.js"> </script>
-<script>
-    (function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){
-                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,"script","//www.google-analytics.com/analytics.js","ga");
-    ga("create", "UA-59827755-9", "auto");
-    ga("send", "pageview");
-</script>
+<script></script>
 </body>
 </html>

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -7,5 +7,6 @@ module.exports = {
   rules: {
     'require-jsdoc': 'off',
     'valid-jsdoc': 'off',
+    'no-unused-vars': ['error', { varsIgnorePattern: 'requiredParams' }],
   },
 };

--- a/test/unit/findings-api.v1.test.js
+++ b/test/unit/findings-api.v1.test.js
@@ -28,7 +28,7 @@ const {
 
 const service = {
   authenticator: new NoAuthAuthenticator(),
-  url: 'https://gateway.watsonplatform.net/findings/findings',
+  url: 'https://sec.advisor.unit.test/findings',
 };
 
 const findingsApi = new FindingsApiV1(service);
@@ -96,6 +96,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'body'];
+
         let err;
         try {
           await findingsApi.postGraph({});
@@ -108,6 +111,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'body'];
+
         const postGraphPromise = findingsApi.postGraph();
         expectToBePromise(postGraphPromise);
 
@@ -124,41 +130,39 @@ describe('FindingsApiV1', () => {
         // parameters
         const accountId = 'fake_accountId';
         const providerId = 'fake_providerId';
-        const newShortDescription = 'fake_newShortDescription';
-        const newLongDescription = 'fake_newLongDescription';
-        const newKind = 'fake_newKind';
-        const newId = 'fake_newId';
-        const newReportedBy = 'fake_newReportedBy';
-        const newName = 'fake_newName';
-        const newRelatedUrl = 'fake_newRelatedUrl';
-        const newExpirationTime = 'fake_newExpirationTime';
-        const newCreateTime = 'fake_newCreateTime';
-        const newUpdateTime = 'fake_newUpdateTime';
-        const newProviderId = 'fake_newProviderId';
-        const newShared = 'fake_newShared';
-        const newFinding = 'fake_newFinding';
-        const newKpi = 'fake_newKpi';
-        const newCard = 'fake_newCard';
-        const newSection = 'fake_newSection';
+        const shortDescription = 'fake_shortDescription';
+        const longDescription = 'fake_longDescription';
+        const kind = 'fake_kind';
+        const id = 'fake_id';
+        const reportedBy = 'fake_reportedBy';
+        const name = 'fake_name';
+        const relatedUrl = 'fake_relatedUrl';
+        const expirationTime = 'fake_expirationTime';
+        const createTime = 'fake_createTime';
+        const updateTime = 'fake_updateTime';
+        const shared = 'fake_shared';
+        const finding = 'fake_finding';
+        const kpi = 'fake_kpi';
+        const card = 'fake_card';
+        const section = 'fake_section';
         const params = {
           accountId,
           providerId,
-          newShortDescription,
-          newLongDescription,
-          newKind,
-          newId,
-          newReportedBy,
-          newName,
-          newRelatedUrl,
-          newExpirationTime,
-          newCreateTime,
-          newUpdateTime,
-          newProviderId,
-          newShared,
-          newFinding,
-          newKpi,
-          newCard,
-          newSection,
+          shortDescription,
+          longDescription,
+          kind,
+          id,
+          reportedBy,
+          name,
+          relatedUrl,
+          expirationTime,
+          createTime,
+          updateTime,
+          shared,
+          finding,
+          kpi,
+          card,
+          section,
         };
 
         const createNoteResult = findingsApi.createNote(params);
@@ -175,22 +179,21 @@ describe('FindingsApiV1', () => {
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body['short_description']).toEqual(newShortDescription);
-        expect(options.body['long_description']).toEqual(newLongDescription);
-        expect(options.body['kind']).toEqual(newKind);
-        expect(options.body['id']).toEqual(newId);
-        expect(options.body['reported_by']).toEqual(newReportedBy);
-        expect(options.body['name']).toEqual(newName);
-        expect(options.body['related_url']).toEqual(newRelatedUrl);
-        expect(options.body['expiration_time']).toEqual(newExpirationTime);
-        expect(options.body['create_time']).toEqual(newCreateTime);
-        expect(options.body['update_time']).toEqual(newUpdateTime);
-        expect(options.body['provider_id']).toEqual(newProviderId);
-        expect(options.body['shared']).toEqual(newShared);
-        expect(options.body['finding']).toEqual(newFinding);
-        expect(options.body['kpi']).toEqual(newKpi);
-        expect(options.body['card']).toEqual(newCard);
-        expect(options.body['section']).toEqual(newSection);
+        expect(options.body['short_description']).toEqual(shortDescription);
+        expect(options.body['long_description']).toEqual(longDescription);
+        expect(options.body['kind']).toEqual(kind);
+        expect(options.body['id']).toEqual(id);
+        expect(options.body['reported_by']).toEqual(reportedBy);
+        expect(options.body['name']).toEqual(name);
+        expect(options.body['related_url']).toEqual(relatedUrl);
+        expect(options.body['expiration_time']).toEqual(expirationTime);
+        expect(options.body['create_time']).toEqual(createTime);
+        expect(options.body['update_time']).toEqual(updateTime);
+        expect(options.body['shared']).toEqual(shared);
+        expect(options.body['finding']).toEqual(finding);
+        expect(options.body['kpi']).toEqual(kpi);
+        expect(options.body['card']).toEqual(card);
+        expect(options.body['section']).toEqual(section);
         expect(options.path['account_id']).toEqual(accountId);
         expect(options.path['provider_id']).toEqual(providerId);
       });
@@ -199,21 +202,21 @@ describe('FindingsApiV1', () => {
         // parameters
         const accountId = 'fake_accountId';
         const providerId = 'fake_providerId';
-        const newShortDescription = 'fake_newShortDescription';
-        const newLongDescription = 'fake_newLongDescription';
-        const newKind = 'fake_newKind';
-        const newId = 'fake_newId';
-        const newReportedBy = 'fake_newReportedBy';
+        const shortDescription = 'fake_shortDescription';
+        const longDescription = 'fake_longDescription';
+        const kind = 'fake_kind';
+        const id = 'fake_id';
+        const reportedBy = 'fake_reportedBy';
         const userAccept = 'fake/header';
         const userContentType = 'fake/header';
         const params = {
           accountId,
           providerId,
-          newShortDescription,
-          newLongDescription,
-          newKind,
-          newId,
-          newReportedBy,
+          shortDescription,
+          longDescription,
+          kind,
+          id,
+          reportedBy,
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
@@ -227,6 +230,17 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = [
+          'accountId',
+          'providerId',
+          'shortDescription',
+          'longDescription',
+          'kind',
+          'id',
+          'reportedBy',
+        ];
+
         let err;
         try {
           await findingsApi.createNote({});
@@ -239,6 +253,17 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = [
+          'accountId',
+          'providerId',
+          'shortDescription',
+          'longDescription',
+          'kind',
+          'id',
+          'reportedBy',
+        ];
+
         const createNotePromise = findingsApi.createNote();
         expectToBePromise(createNotePromise);
 
@@ -306,6 +331,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId'];
+
         let err;
         try {
           await findingsApi.listNotes({});
@@ -318,6 +346,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId'];
+
         const listNotesPromise = findingsApi.listNotes();
         expectToBePromise(listNotesPromise);
 
@@ -388,6 +419,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'noteId'];
+
         let err;
         try {
           await findingsApi.getNote({});
@@ -400,6 +434,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'noteId'];
+
         const getNotePromise = findingsApi.getNote();
         expectToBePromise(getNotePromise);
 
@@ -417,42 +454,40 @@ describe('FindingsApiV1', () => {
         const accountId = 'fake_accountId';
         const providerId = 'fake_providerId';
         const noteId = 'fake_noteId';
-        const newShortDescription = 'fake_newShortDescription';
-        const newLongDescription = 'fake_newLongDescription';
-        const newKind = 'fake_newKind';
-        const newId = 'fake_newId';
-        const newReportedBy = 'fake_newReportedBy';
-        const newName = 'fake_newName';
-        const newRelatedUrl = 'fake_newRelatedUrl';
-        const newExpirationTime = 'fake_newExpirationTime';
-        const newCreateTime = 'fake_newCreateTime';
-        const newUpdateTime = 'fake_newUpdateTime';
-        const newProviderId = 'fake_newProviderId';
-        const newShared = 'fake_newShared';
-        const newFinding = 'fake_newFinding';
-        const newKpi = 'fake_newKpi';
-        const newCard = 'fake_newCard';
-        const newSection = 'fake_newSection';
+        const shortDescription = 'fake_shortDescription';
+        const longDescription = 'fake_longDescription';
+        const kind = 'fake_kind';
+        const id = 'fake_id';
+        const reportedBy = 'fake_reportedBy';
+        const name = 'fake_name';
+        const relatedUrl = 'fake_relatedUrl';
+        const expirationTime = 'fake_expirationTime';
+        const createTime = 'fake_createTime';
+        const updateTime = 'fake_updateTime';
+        const shared = 'fake_shared';
+        const finding = 'fake_finding';
+        const kpi = 'fake_kpi';
+        const card = 'fake_card';
+        const section = 'fake_section';
         const params = {
           accountId,
           providerId,
           noteId,
-          newShortDescription,
-          newLongDescription,
-          newKind,
-          newId,
-          newReportedBy,
-          newName,
-          newRelatedUrl,
-          newExpirationTime,
-          newCreateTime,
-          newUpdateTime,
-          newProviderId,
-          newShared,
-          newFinding,
-          newKpi,
-          newCard,
-          newSection,
+          shortDescription,
+          longDescription,
+          kind,
+          id,
+          reportedBy,
+          name,
+          relatedUrl,
+          expirationTime,
+          createTime,
+          updateTime,
+          shared,
+          finding,
+          kpi,
+          card,
+          section,
         };
 
         const updateNoteResult = findingsApi.updateNote(params);
@@ -473,22 +508,21 @@ describe('FindingsApiV1', () => {
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body['short_description']).toEqual(newShortDescription);
-        expect(options.body['long_description']).toEqual(newLongDescription);
-        expect(options.body['kind']).toEqual(newKind);
-        expect(options.body['id']).toEqual(newId);
-        expect(options.body['reported_by']).toEqual(newReportedBy);
-        expect(options.body['name']).toEqual(newName);
-        expect(options.body['related_url']).toEqual(newRelatedUrl);
-        expect(options.body['expiration_time']).toEqual(newExpirationTime);
-        expect(options.body['create_time']).toEqual(newCreateTime);
-        expect(options.body['update_time']).toEqual(newUpdateTime);
-        expect(options.body['provider_id']).toEqual(newProviderId);
-        expect(options.body['shared']).toEqual(newShared);
-        expect(options.body['finding']).toEqual(newFinding);
-        expect(options.body['kpi']).toEqual(newKpi);
-        expect(options.body['card']).toEqual(newCard);
-        expect(options.body['section']).toEqual(newSection);
+        expect(options.body['short_description']).toEqual(shortDescription);
+        expect(options.body['long_description']).toEqual(longDescription);
+        expect(options.body['kind']).toEqual(kind);
+        expect(options.body['id']).toEqual(id);
+        expect(options.body['reported_by']).toEqual(reportedBy);
+        expect(options.body['name']).toEqual(name);
+        expect(options.body['related_url']).toEqual(relatedUrl);
+        expect(options.body['expiration_time']).toEqual(expirationTime);
+        expect(options.body['create_time']).toEqual(createTime);
+        expect(options.body['update_time']).toEqual(updateTime);
+        expect(options.body['shared']).toEqual(shared);
+        expect(options.body['finding']).toEqual(finding);
+        expect(options.body['kpi']).toEqual(kpi);
+        expect(options.body['card']).toEqual(card);
+        expect(options.body['section']).toEqual(section);
         expect(options.path['account_id']).toEqual(accountId);
         expect(options.path['provider_id']).toEqual(providerId);
         expect(options.path['note_id']).toEqual(noteId);
@@ -499,22 +533,22 @@ describe('FindingsApiV1', () => {
         const accountId = 'fake_accountId';
         const providerId = 'fake_providerId';
         const noteId = 'fake_noteId';
-        const newShortDescription = 'fake_newShortDescription';
-        const newLongDescription = 'fake_newLongDescription';
-        const newKind = 'fake_newKind';
-        const newId = 'fake_newId';
-        const newReportedBy = 'fake_newReportedBy';
+        const shortDescription = 'fake_shortDescription';
+        const longDescription = 'fake_longDescription';
+        const kind = 'fake_kind';
+        const id = 'fake_id';
+        const reportedBy = 'fake_reportedBy';
         const userAccept = 'fake/header';
         const userContentType = 'fake/header';
         const params = {
           accountId,
           providerId,
           noteId,
-          newShortDescription,
-          newLongDescription,
-          newKind,
-          newId,
-          newReportedBy,
+          shortDescription,
+          longDescription,
+          kind,
+          id,
+          reportedBy,
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
@@ -528,6 +562,18 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = [
+          'accountId',
+          'providerId',
+          'noteId',
+          'shortDescription',
+          'longDescription',
+          'kind',
+          'id',
+          'reportedBy',
+        ];
+
         let err;
         try {
           await findingsApi.updateNote({});
@@ -540,6 +586,18 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = [
+          'accountId',
+          'providerId',
+          'noteId',
+          'shortDescription',
+          'longDescription',
+          'kind',
+          'id',
+          'reportedBy',
+        ];
+
         const updateNotePromise = findingsApi.updateNote();
         expectToBePromise(updateNotePromise);
 
@@ -610,6 +668,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'noteId'];
+
         let err;
         try {
           await findingsApi.deleteNote({});
@@ -622,6 +683,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'noteId'];
+
         const deleteNotePromise = findingsApi.deleteNote();
         expectToBePromise(deleteNotePromise);
 
@@ -692,6 +756,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'occurrenceId'];
+
         let err;
         try {
           await findingsApi.getOccurrenceNote({});
@@ -704,6 +771,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'occurrenceId'];
+
         const getOccurrenceNotePromise = findingsApi.getOccurrenceNote();
         expectToBePromise(getOccurrenceNotePromise);
 
@@ -720,34 +790,32 @@ describe('FindingsApiV1', () => {
         // parameters
         const accountId = 'fake_accountId';
         const providerId = 'fake_providerId';
-        const newNoteName = 'fake_newNoteName';
-        const newKind = 'fake_newKind';
-        const newId = 'fake_newId';
-        const newName = 'fake_newName';
-        const newResourceUrl = 'fake_newResourceUrl';
-        const newRemediation = 'fake_newRemediation';
-        const newCreateTime = 'fake_newCreateTime';
-        const newUpdateTime = 'fake_newUpdateTime';
-        const newProviderId = 'fake_newProviderId';
-        const newContext = 'fake_newContext';
-        const newFinding = 'fake_newFinding';
-        const newKpi = 'fake_newKpi';
+        const noteName = 'fake_noteName';
+        const kind = 'fake_kind';
+        const id = 'fake_id';
+        const name = 'fake_name';
+        const resourceUrl = 'fake_resourceUrl';
+        const remediation = 'fake_remediation';
+        const createTime = 'fake_createTime';
+        const updateTime = 'fake_updateTime';
+        const context = 'fake_context';
+        const finding = 'fake_finding';
+        const kpi = 'fake_kpi';
         const replaceIfExists = 'fake_replaceIfExists';
         const params = {
           accountId,
           providerId,
-          newNoteName,
-          newKind,
-          newId,
-          newName,
-          newResourceUrl,
-          newRemediation,
-          newCreateTime,
-          newUpdateTime,
-          newProviderId,
-          newContext,
-          newFinding,
-          newKpi,
+          noteName,
+          kind,
+          id,
+          name,
+          resourceUrl,
+          remediation,
+          createTime,
+          updateTime,
+          context,
+          finding,
+          kpi,
           replaceIfExists,
         };
 
@@ -766,18 +834,17 @@ describe('FindingsApiV1', () => {
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'Replace-If-Exists', replaceIfExists);
-        expect(options.body['note_name']).toEqual(newNoteName);
-        expect(options.body['kind']).toEqual(newKind);
-        expect(options.body['id']).toEqual(newId);
-        expect(options.body['name']).toEqual(newName);
-        expect(options.body['resource_url']).toEqual(newResourceUrl);
-        expect(options.body['remediation']).toEqual(newRemediation);
-        expect(options.body['create_time']).toEqual(newCreateTime);
-        expect(options.body['update_time']).toEqual(newUpdateTime);
-        expect(options.body['provider_id']).toEqual(newProviderId);
-        expect(options.body['context']).toEqual(newContext);
-        expect(options.body['finding']).toEqual(newFinding);
-        expect(options.body['kpi']).toEqual(newKpi);
+        expect(options.body['note_name']).toEqual(noteName);
+        expect(options.body['kind']).toEqual(kind);
+        expect(options.body['id']).toEqual(id);
+        expect(options.body['name']).toEqual(name);
+        expect(options.body['resource_url']).toEqual(resourceUrl);
+        expect(options.body['remediation']).toEqual(remediation);
+        expect(options.body['create_time']).toEqual(createTime);
+        expect(options.body['update_time']).toEqual(updateTime);
+        expect(options.body['context']).toEqual(context);
+        expect(options.body['finding']).toEqual(finding);
+        expect(options.body['kpi']).toEqual(kpi);
         expect(options.path['account_id']).toEqual(accountId);
         expect(options.path['provider_id']).toEqual(providerId);
       });
@@ -786,17 +853,17 @@ describe('FindingsApiV1', () => {
         // parameters
         const accountId = 'fake_accountId';
         const providerId = 'fake_providerId';
-        const newNoteName = 'fake_newNoteName';
-        const newKind = 'fake_newKind';
-        const newId = 'fake_newId';
+        const noteName = 'fake_noteName';
+        const kind = 'fake_kind';
+        const id = 'fake_id';
         const userAccept = 'fake/header';
         const userContentType = 'fake/header';
         const params = {
           accountId,
           providerId,
-          newNoteName,
-          newKind,
-          newId,
+          noteName,
+          kind,
+          id,
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
@@ -810,6 +877,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'noteName', 'kind', 'id'];
+
         let err;
         try {
           await findingsApi.createOccurrence({});
@@ -822,6 +892,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'noteName', 'kind', 'id'];
+
         const createOccurrencePromise = findingsApi.createOccurrence();
         expectToBePromise(createOccurrencePromise);
 
@@ -889,6 +962,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId'];
+
         let err;
         try {
           await findingsApi.listOccurrences({});
@@ -901,6 +977,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId'];
+
         const listOccurrencesPromise = findingsApi.listOccurrences();
         expectToBePromise(listOccurrencesPromise);
 
@@ -977,6 +1056,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'noteId'];
+
         let err;
         try {
           await findingsApi.listNoteOccurrences({});
@@ -989,6 +1071,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'noteId'];
+
         const listNoteOccurrencesPromise = findingsApi.listNoteOccurrences();
         expectToBePromise(listNoteOccurrencesPromise);
 
@@ -1059,6 +1144,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'occurrenceId'];
+
         let err;
         try {
           await findingsApi.getOccurrence({});
@@ -1071,6 +1159,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'occurrenceId'];
+
         const getOccurrencePromise = findingsApi.getOccurrence();
         expectToBePromise(getOccurrencePromise);
 
@@ -1088,34 +1179,32 @@ describe('FindingsApiV1', () => {
         const accountId = 'fake_accountId';
         const providerId = 'fake_providerId';
         const occurrenceId = 'fake_occurrenceId';
-        const newNoteName = 'fake_newNoteName';
-        const newKind = 'fake_newKind';
-        const newId = 'fake_newId';
-        const newName = 'fake_newName';
-        const newResourceUrl = 'fake_newResourceUrl';
-        const newRemediation = 'fake_newRemediation';
-        const newCreateTime = 'fake_newCreateTime';
-        const newUpdateTime = 'fake_newUpdateTime';
-        const newProviderId = 'fake_newProviderId';
-        const newContext = 'fake_newContext';
-        const newFinding = 'fake_newFinding';
-        const newKpi = 'fake_newKpi';
+        const noteName = 'fake_noteName';
+        const kind = 'fake_kind';
+        const id = 'fake_id';
+        const name = 'fake_name';
+        const resourceUrl = 'fake_resourceUrl';
+        const remediation = 'fake_remediation';
+        const createTime = 'fake_createTime';
+        const updateTime = 'fake_updateTime';
+        const context = 'fake_context';
+        const finding = 'fake_finding';
+        const kpi = 'fake_kpi';
         const params = {
           accountId,
           providerId,
           occurrenceId,
-          newNoteName,
-          newKind,
-          newId,
-          newName,
-          newResourceUrl,
-          newRemediation,
-          newCreateTime,
-          newUpdateTime,
-          newProviderId,
-          newContext,
-          newFinding,
-          newKpi,
+          noteName,
+          kind,
+          id,
+          name,
+          resourceUrl,
+          remediation,
+          createTime,
+          updateTime,
+          context,
+          finding,
+          kpi,
         };
 
         const updateOccurrenceResult = findingsApi.updateOccurrence(params);
@@ -1136,18 +1225,17 @@ describe('FindingsApiV1', () => {
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body['note_name']).toEqual(newNoteName);
-        expect(options.body['kind']).toEqual(newKind);
-        expect(options.body['id']).toEqual(newId);
-        expect(options.body['name']).toEqual(newName);
-        expect(options.body['resource_url']).toEqual(newResourceUrl);
-        expect(options.body['remediation']).toEqual(newRemediation);
-        expect(options.body['create_time']).toEqual(newCreateTime);
-        expect(options.body['update_time']).toEqual(newUpdateTime);
-        expect(options.body['provider_id']).toEqual(newProviderId);
-        expect(options.body['context']).toEqual(newContext);
-        expect(options.body['finding']).toEqual(newFinding);
-        expect(options.body['kpi']).toEqual(newKpi);
+        expect(options.body['note_name']).toEqual(noteName);
+        expect(options.body['kind']).toEqual(kind);
+        expect(options.body['id']).toEqual(id);
+        expect(options.body['name']).toEqual(name);
+        expect(options.body['resource_url']).toEqual(resourceUrl);
+        expect(options.body['remediation']).toEqual(remediation);
+        expect(options.body['create_time']).toEqual(createTime);
+        expect(options.body['update_time']).toEqual(updateTime);
+        expect(options.body['context']).toEqual(context);
+        expect(options.body['finding']).toEqual(finding);
+        expect(options.body['kpi']).toEqual(kpi);
         expect(options.path['account_id']).toEqual(accountId);
         expect(options.path['provider_id']).toEqual(providerId);
         expect(options.path['occurrence_id']).toEqual(occurrenceId);
@@ -1158,18 +1246,18 @@ describe('FindingsApiV1', () => {
         const accountId = 'fake_accountId';
         const providerId = 'fake_providerId';
         const occurrenceId = 'fake_occurrenceId';
-        const newNoteName = 'fake_newNoteName';
-        const newKind = 'fake_newKind';
-        const newId = 'fake_newId';
+        const noteName = 'fake_noteName';
+        const kind = 'fake_kind';
+        const id = 'fake_id';
         const userAccept = 'fake/header';
         const userContentType = 'fake/header';
         const params = {
           accountId,
           providerId,
           occurrenceId,
-          newNoteName,
-          newKind,
-          newId,
+          noteName,
+          kind,
+          id,
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
@@ -1183,6 +1271,16 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = [
+          'accountId',
+          'providerId',
+          'occurrenceId',
+          'noteName',
+          'kind',
+          'id',
+        ];
+
         let err;
         try {
           await findingsApi.updateOccurrence({});
@@ -1195,6 +1293,16 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = [
+          'accountId',
+          'providerId',
+          'occurrenceId',
+          'noteName',
+          'kind',
+          'id',
+        ];
+
         const updateOccurrencePromise = findingsApi.updateOccurrence();
         expectToBePromise(updateOccurrencePromise);
 
@@ -1265,6 +1373,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'occurrenceId'];
+
         let err;
         try {
           await findingsApi.deleteOccurrence({});
@@ -1277,6 +1388,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId', 'providerId', 'occurrenceId'];
+
         const deleteOccurrencePromise = findingsApi.deleteOccurrence();
         expectToBePromise(deleteOccurrencePromise);
 
@@ -1339,6 +1453,9 @@ describe('FindingsApiV1', () => {
 
     describe('negative tests', () => {
       test('should enforce required parameters', async done => {
+        // required parameters for this method
+        const requiredParams = ['accountId'];
+
         let err;
         try {
           await findingsApi.listProviders({});
@@ -1351,6 +1468,9 @@ describe('FindingsApiV1', () => {
       });
 
       test('should reject promise when required params are not given', done => {
+        // required parameters for this method
+        const requiredParams = ['accountId'];
+
         const listProvidersPromise = findingsApi.listProviders();
         expectToBePromise(listProvidersPromise);
 


### PR DESCRIPTION
Create Notes etc required parameters to be prefixed with new.
For example, newId, newKind etc due to a bug in swagger API.
