### PR TITLE
Added support for critical severity

### DIFF
--- a/examples/resources/channels.js
+++ b/examples/resources/channels.js
@@ -3,7 +3,7 @@ module.exports = [
     name: 'Channel1',
     description: 'My channel1',
     type: 'Webhook',
-    severity: ['low'],
+    severity: ['low', 'critical'],
     endpoint: 'http://mywebhook.com',
     enabled: true,
     alertSource: [

--- a/examples/resources/notes.js
+++ b/examples/resources/notes.js
@@ -41,7 +41,7 @@ module.exports = [
       url: 'https://www.example.com',
     },
     finding: {
-      severity: 'HIGH',
+      severity: 'CRITICAL',
       next_steps: [
         {
           title: 'Fix this.',

--- a/findings-api/v1.ts
+++ b/findings-api/v1.ts
@@ -1506,7 +1506,7 @@ namespace FindingsApiV1 {
     image: string;
   }
 
-  /** Note provider-assigned severity/impact ranking - LOW&#58; Low Impact - MEDIUM&#58; Medium Impact - HIGH&#58; High Impact. */
+  /** Note provider-assigned severity/impact ranking - LOW&#58; Low Impact - MEDIUM&#58; Medium Impact - HIGH&#58; High Impact - CRITICAL&#58; Critical Impact. */
   export interface Severity {}
 
   /** It provides details about a socket address. */

--- a/notifications-api/v1.ts
+++ b/notifications-api/v1.ts
@@ -646,6 +646,7 @@ namespace NotificationsApiV1 {
       LOW = 'low',
       MEDIUM = 'medium',
       HIGH = 'high',
+      CRITICAL = 'critical',
     }
   }
 
@@ -708,6 +709,7 @@ namespace NotificationsApiV1 {
       LOW = 'low',
       MEDIUM = 'medium',
       HIGH = 'high',
+      CRITICAL = 'critical',
     }
   }
 
@@ -768,6 +770,8 @@ namespace NotificationsApiV1 {
 
   /** Severity of the notification. */
   export interface ChannelResponseDefinitionSeverity {
+    /** Critical Severity. */
+    critical?: boolean;
     /** High Severity. */
     high?: boolean;
     /** Medium Severity. */
@@ -832,6 +836,8 @@ namespace NotificationsApiV1 {
 
   /** Severity of the notification. */
   export interface GetChannelResponseChannelSeverity {
+    /** Critical Severity. */
+    critical?: boolean;
     /** High Severity. */
     high?: boolean;
     /** Medium Severity. */


### PR DESCRIPTION
- [X] `npm test` passes (tip: `npm run autofix` can correct most style issues)
